### PR TITLE
Remove Command interface, as per latest Tactician

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php":  ">=5.5",
-    "league/tactician": "^0.3",
+    "league/tactician": "^0.4",
     "league/container": "~1.3"
   },
   "require-dev": {

--- a/src/ContainerLocator.php
+++ b/src/ContainerLocator.php
@@ -3,7 +3,6 @@
 namespace League\Tactician\Container;
 
 use League\Container\Container;
-use League\Tactician\Container\Exception\MissingContainerServiceException;
 use League\Tactician\Command;
 use League\Tactician\Exception\MissingHandlerException;
 use League\Tactician\Handler\Locator\HandlerLocator;
@@ -76,11 +75,11 @@ class ContainerLocator implements HandlerLocator
     /**
      * Retrieve handler for the given command
      *
-     * @param Command $command The command object
+     * @param object $command The command object
      * @return Object
      * @throws MissingHandlerException
      */
-    public function getHandlerForCommand(Command $command)
+    public function getHandlerForCommand($command)
     {
         $className = get_class($command);
 

--- a/tests/ContainerLocatorTest.php
+++ b/tests/ContainerLocatorTest.php
@@ -13,7 +13,7 @@ use Test\League\Tactician\Container\Fixtures\Handlers\CompleteTaskCommandHandler
 
 class ContainerLocatorTest extends PHPUnit_Framework_TestCase
 {
-    /** @var  ContainerLocator */
+    /** @var ContainerLocator */
     private $containerLocator;
 
     protected function setUp()

--- a/tests/Fixtures/Commands/CompleteTaskCommand.php
+++ b/tests/Fixtures/Commands/CompleteTaskCommand.php
@@ -2,8 +2,6 @@
 
 namespace Test\League\Tactician\Container\Fixtures\Commands;
 
-use League\Tactician\Command;
-
-class CompleteTaskCommand implements Command
+class CompleteTaskCommand
 {
 }

--- a/tests/Fixtures/Commands/DeleteTaskCommand.php
+++ b/tests/Fixtures/Commands/DeleteTaskCommand.php
@@ -2,8 +2,6 @@
 
 namespace Test\League\Tactician\Container\Fixtures\Commands;
 
-use League\Tactician\Command;
-
-class DeleteTaskCommand implements Command
+class DeleteTaskCommand
 {
 }

--- a/tests/Fixtures/Handlers/CompleteTaskCommandHandler.php
+++ b/tests/Fixtures/Handlers/CompleteTaskCommandHandler.php
@@ -2,7 +2,6 @@
 
 namespace Test\League\Tactician\Container\Fixtures\Handlers;
 
-use League\Tactician\Command;
 use Test\League\Tactician\Container\Fixtures\Container\Mailer;
 
 class CompleteTaskCommandHandler
@@ -14,7 +13,7 @@ class CompleteTaskCommandHandler
         $this->mailer = $mailer;
     }
 
-    public function handleCompleteTaskCommand(Command $command)
+    public function handleCompleteTaskCommand($command)
     {
     }
 }


### PR DESCRIPTION
See https://github.com/thephpleague/tactician/issues/43 and https://github.com/thephpleague/tactician/issues/45. Waiting to get all the plugins ready, then I'll merge Tactician, then the plugins and do the releases. 
