### PR TITLE
Use container-interop instead of direct dependency on league/container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,12 @@
     "require": {
         "php": ">=5.5",
         "league/tactician": "^0.6",
-        "league/container": "~1.3"
+        "container-interop/container-interop": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.3",
-        "squizlabs/php_codesniffer": "~2.0"
+        "squizlabs/php_codesniffer": "~2.0",
+        "league/container": "~2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/ContainerLocator.php
+++ b/src/ContainerLocator.php
@@ -2,7 +2,7 @@
 
 namespace League\Tactician\Container;
 
-use League\Container\ContainerInterface;
+use Interop\Container\ContainerInterface;
 use League\Tactician\Exception\MissingHandlerException;
 use League\Tactician\Handler\Locator\HandlerLocator;
 

--- a/tests/ContainerLocatorTest.php
+++ b/tests/ContainerLocatorTest.php
@@ -3,6 +3,7 @@
 namespace League\Tactician\Container;
 
 use League\Container\Container;
+use League\Container\ReflectionContainer;
 use League\Tactician\Container\ContainerLocator;
 use League\Tactician\Container\Test\Fixtures\Commands\CompleteTaskCommand;
 use League\Tactician\Container\Test\Fixtures\Commands\DeleteTaskCommand;
@@ -18,26 +19,21 @@ class ContainerLocatorTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $dic = [
-            'di' => [
-                'Mailer' => [
-                    'class' => Mailer::class,
-                ],
-                'CompleteTaskCommandHandler' => [
-                    'class' => CompleteTaskCommand::class,
-                    'arguments' => [
-                        'Mailer',
-                    ],
-                ],
-            ],
-        ];
+
+        $container = new Container;
+        $container->delegate(
+            new ReflectionContainer
+        );
+        $container->add('Mailer', Mailer::class);
+        $container->add('CompleteTaskCommandHandler', CompleteTaskCommand::class)
+                  ->withArgument('Mailer');
 
         $mapping = [
             CompleteTaskCommand::class => CompleteTaskCommandHandler::class,
         ];
 
         $this->containerLocator = new ContainerLocator(
-            new Container($dic),
+            $container,
             $mapping
         );
     }


### PR DESCRIPTION
The 2.x branch of league/container implements container-interop/container-interop
https://github.com/container-interop/container-interop

This will allow this package to work with any di container that implements Interop\Container\ContainerInterface including League Container v2.
